### PR TITLE
Make the code more readable

### DIFF
--- a/code-editor.html
+++ b/code-editor.html
@@ -251,9 +251,10 @@ CodeMirror.on(modeInput, "keypress", function(e) {
   if (e.keyCode == 13) change();
 });
 function change() {
-  var val = modeInput.value, m, mode, spec;
-  if (m = /.+\.([^.]+)$/.exec(val)) {
-    var info = CodeMirror.findModeByExtension(m[1]);
+  var val = modeInput.value, mode, spec;
+  if (/.+\.([^.]+)$/.exec(val)) {
+    var result = /.+\.([^.]+)$/.exec(val);
+    var info = CodeMirror.findModeByExtension(result[1]);
     if (info) {
       mode = info.mode;
       spec = info.mime;


### PR DESCRIPTION
`m` isn't used outside of the `if` statement, so I moved it into its scope and renamed it result. `/.+\.([^.]+)$/.exec(val)` is executed twice, but an optimal JavaScript engine should optimize that into one call (since it's a standard library function, it has no side effects, and `val` hasn't changed). This should overall make the code more readable.
