### PR TITLE
Refactor JS into separate file, edit JS's style, add saving function

### DIFF
--- a/code-editor.html
+++ b/code-editor.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <title>Code editor</title>
+  <title>Code Editor</title>
   <link rel="shortcut icon" href="./favicon.ico" type="image/x-icon">
   <link rel="icon" href="./favicon.ico" type="image/x-icon">
   <meta charset="utf-8" />
@@ -87,12 +87,11 @@
 
 <body>
   <form>
-    <textarea id="code" name="code">
-    </textarea>
+    <textarea id="code" name="code"></textarea>
   </form>
   <p>
     Theme:
-    <select onchange="selectTheme()" id=select>
+    <select onchange="selectTheme(input.options[input.selectedIndex].textContent)" id="select">
       <option>default</option>
       <option>3024-day</option>
       <option>3024-night</option>
@@ -143,7 +142,7 @@
   </p>
   <p>
     language:
-    <select onchange="change()" id=mode>
+    <select onchange="change(modeInput.value)" id="mode">
       <option>apl</option>
       <option>asciiarmor</option>
       <option>asn.1</option>
@@ -186,7 +185,7 @@
       <option>http</option>
       <option>idl</option>
       <option>jade</option>
-      <option>javascript</option>
+      <option selected>javascript</option>
       <option>jinja2</option>
       <option>julia</option>
       <option>livescript</option>
@@ -254,7 +253,7 @@
       <option>yaml</option>
       <option>z80</option>
     </select>
-    <select onchange="setClikeMode()" id=selectClikeLanguage>
+    <select onchange="setClikeMode(document.getElementById('selectClikeLanguage').value)" id="selectClikeLanguage">
       <option>C</option>
       <option>C++</option>
       <option>C#</option>
@@ -270,127 +269,13 @@
     <br> gfm: github-flavored markdown
     <br> htmlmixed: html with javascript
     <br> ctrl-space for autocompletion
+    <br> ctrl-s for saving (only supports js, java, html for now)
   </p>
   <p></p>
   <p style="color: gray">Current language:
     <span id="modeinfo">text/plain</span>
   </p>
-  <script>
-    document.getElementById("selectClikeLanguage").style.visibility = 'hidden';
-
-    CodeMirror.modeURL = "./node_modules/codemirror/mode/%N/%N.js";
-    var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
-      lineNumbers: true,
-      styleActiveLine: true,
-      matchBrackets: true,
-      extraKeys: {
-        "Ctrl-Space": "autocomplete"
-      },
-      autoCloseBrackets: true,
-      autoCloseTags: true,
-      highlightSelectionMatches: {
-        showToken: /\w/
-      }
-    });
-
-    var modeInput = document.getElementById("mode");
-    CodeMirror.on(modeInput, "keypress", function(e) {
-      if (e.keyCode == 13) change();
-    });
-
-    function change() {
-      if (document.getElementById("mode").value == "clike") {
-        document.getElementById("selectClikeLanguage").style.visibility = 'visible';
-      } else {
-        document.getElementById("selectClikeLanguage").style.visibility = 'hidden';
-      }
-
-      var val = modeInput.value,
-        mode, spec;
-      if (/.+\.([^.]+)$/.exec(val)) {
-        var result = /.+\.([^.]+)$/.exec(val);
-        var info = CodeMirror.findModeByExtension(result[1]);
-        if (info) {
-          mode = info.mode;
-          spec = info.mime;
-        }
-      } else if (/\//.test(val)) {
-        var info = CodeMirror.findModeByMIME(val);
-        if (info) {
-          mode = info.mode;
-          spec = val;
-        }
-      } else {
-        mode = spec = val;
-      }
-      if (mode) {
-        editor.setOption("mode", spec);
-        CodeMirror.autoLoadMode(editor, mode);
-        document.getElementById("modeinfo").textContent = spec;
-      } else {
-        alert("Could not find a mode corresponding to " + val);
-      }
-    }
-
-    function setClikeMode() {
-      switch (document.getElementById("selectClikeLanguage").value) {
-        case "C":
-          editor.setOption("mode", "text/x-csrc");
-          document.getElementById("modeinfo").textContent = "C";
-          break;
-        case "C++":
-          editor.setOption("mode", "text/x-c++src");
-          document.getElementById("modeinfo").textContent = "C++";
-          break;
-        case "C#":
-          editor.setOption("mode", "text/x-csharp");
-          document.getElementById("modeinfo").textContent = "C#";
-          break;
-        case "Java":
-          editor.setOption("mode", "text/x-java");
-          document.getElementById("modeinfo").textContent = "Java";
-          break;
-        case "Obj C":
-          editor.setOption("mode", "text/x-objectivec");
-          document.getElementById("modeinfo").textContent = "Objective C";
-          break;
-        case "Scala":
-          editor.setOption("mode", "text/x-scala");
-          document.getElementById("modeinfo").textContent = "Scala";
-          break;
-        case "Kotlin":
-          editor.setOption("mode", "text/x-kotlin");
-          document.getElementById("modeinfo").textContent = "Kotlin";
-          break;
-        case "Ceylon":
-          editor.setOption("mode", "text/x-ceylon");
-          document.getElementById("modeinfo").textContent = "Ceylon";
-          break;
-      }
-    }
-
-    var input = document.getElementById("select");
-
-    function selectTheme() {
-      var theme = input.options[input.selectedIndex].textContent;
-      editor.setOption("theme", theme);
-      location.hash = "#" + theme;
-    }
-    var choice = (location.hash && location.hash.slice(1)) ||
-      (document.location.search &&
-        decodeURIComponent(document.location.search.slice(1)));
-    if (choice) {
-      input.value = choice;
-      editor.setOption("theme", choice);
-    }
-    CodeMirror.on(window, "hashchange", function() {
-      var theme = location.hash.slice(1);
-      if (theme) {
-        input.value = theme;
-        selectTheme();
-      }
-    });
-  </script>
+  <script src="code-editor.js"></script>
 </body>
 
 </html>

--- a/code-editor.js
+++ b/code-editor.js
@@ -1,0 +1,156 @@
+document.getElementById('selectClikeLanguage').style.visibility = 'hidden'
+
+CodeMirror.modeURL = './node_modules/codemirror/mode/%N/%N.js'
+var editor = CodeMirror.fromTextArea(document.getElementById('code'), {
+  lineNumbers: true,
+  styleActiveLine: true,
+  matchBrackets: true,
+  extraKeys: {
+    'Ctrl-Space': 'autocomplete'
+  },
+  autoCloseBrackets: true,
+  autoCloseTags: true,
+  highlightSelectionMatches: {
+    showToken: /\w/
+  }
+})
+
+var modeInput = document.getElementById('mode')
+CodeMirror.on(modeInput, 'keypress', function(e) {
+  if (e.keyCode == 13) change()
+})
+
+function change(val) {
+  if (val == 'clike') {
+    document.getElementById('selectClikeLanguage').style.visibility = 'visible'
+  } else {
+    document.getElementById('selectClikeLanguage').style.visibility = 'hidden'
+  }
+
+  var mode, spec
+  if (/.+\.([^.]+)$/.exec(val)) {
+    var result = /.+\.([^.]+)$/.exec(val)
+    var info = CodeMirror.findModeByExtension(result[1])
+    if (info) {
+      mode = info.mode
+      spec = info.mime
+    }
+  } else if (/\//.test(val)) {
+    var info = CodeMirror.findModeByMIME(val)
+    if (info) {
+      mode = info.mode
+      spec = val
+    }
+  } else {
+    mode = spec = val
+  }
+  if (mode) {
+    editor.setOption('mode', spec)
+    CodeMirror.autoLoadMode(editor, mode)
+    document.getElementById('modeinfo').textContent = spec
+  } else {
+    alert('Could not find a mode corresponding to ' + val)
+  }
+}
+
+function setClikeMode(mode) {
+  switch (mode) {
+    case 'C':
+      editor.setOption('mode', 'text/x-csrc')
+      document.getElementById('modeinfo').textContent = 'C'
+      break
+    case 'C++':
+      editor.setOption('mode', 'text/x-c++src')
+      document.getElementById('modeinfo').textContent = 'C++'
+      break
+    case 'C#':
+      editor.setOption('mode', 'text/x-csharp')
+      document.getElementById('modeinfo').textContent = 'C#'
+      break
+    case 'Java':
+      editor.setOption('mode', 'text/x-java')
+      document.getElementById('modeinfo').textContent = 'Java'
+      break
+    case 'Obj C':
+      editor.setOption('mode', 'text/x-objectivec')
+      document.getElementById('modeinfo').textContent = 'Objective C'
+      break
+    case 'Scala':
+      editor.setOption('mode', 'text/x-scala')
+      document.getElementById('modeinfo').textContent = 'Scala'
+      break
+    case 'Kotlin':
+      editor.setOption('mode', 'text/x-kotlin')
+      document.getElementById('modeinfo').textContent = 'Kotlin'
+      break
+    case 'Ceylon':
+      editor.setOption('mode', 'text/x-ceylon')
+      document.getElementById('modeinfo').textContent = 'Ceylon'
+      break
+  }
+}
+
+var input = document.getElementById('select')
+
+function selectTheme(theme) {
+  editor.setOption('theme', theme)
+  location.hash = '#' + theme
+}
+var choice = (location.hash && location.hash.slice(1)) ||
+  (document.location.search &&
+    decodeURIComponent(document.location.search.slice(1)))
+if (choice) {
+  input.value = choice
+  selectTheme(choice)
+}
+CodeMirror.on(window, 'hashchange', function() {
+  var theme = location.hash.slice(1)
+  if (theme) {
+    input.value = theme
+    selectTheme(theme)
+  }
+})
+
+function download(filename, text) {
+  var pom = document.createElement('a');
+  pom.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+  pom.setAttribute('download', filename);
+
+  if (document.createEvent) {
+    var event = document.createEvent('MouseEvents');
+    event.initEvent('click', true, true);
+    pom.dispatchEvent(event);
+  } else {
+    pom.click();
+  }
+  return text
+}
+
+function getExtension(mode) {
+  switch (mode) {
+    case 'javascript':
+      return 'js'
+    case 'text/x-java':
+      return 'java'
+    case 'htmlembedded':
+    case 'htmlmixed':
+      return 'html'
+  }
+}
+
+function save() {
+  var output = ''
+  for (var i = 0; i < editor.lineCount(); i++) output += editor.getLine(i) + '\r\n'
+  var filename = prompt('Filename', 'code.' + getExtension(editor.getOption('mode')))
+  if (!filename) return null
+  return download(filename, output)
+}
+
+window.addEventListener('keydown', function(event) {
+    if ((event.ctrlKey || event.metaKey) && String.fromCharCode(event.which).toLowerCase() == 's') {
+      event.preventDefault()
+      save()
+    }
+})
+
+change('javascript')


### PR DESCRIPTION
JavaScript Restyling: Follows [npm coding style](https://docs.npmjs.com/misc/coding-style)
- No semicolons, not needed or recommended in JavaScript
- Single quotes

Added saving with Ctrl-S

JavaScript is now in its own file
